### PR TITLE
Fix title of column "title" in places list

### DIFF
--- a/src/views/GrampsjsViewPlaces.js
+++ b/src/views/GrampsjsViewPlaces.js
@@ -14,7 +14,7 @@ export class GrampsjsViewPlaces extends GrampsjsViewObjectsBase {
     super()
     this._columns = {
       grampsId: {title: 'Gramps ID', sort: 'gramps_id'},
-      title: {tite: 'Title', sort: 'title'},
+      title: {title: 'Title', sort: 'title'},
       change: {title: 'Last changed', sort: 'change'},
     }
   }


### PR DESCRIPTION
The column "title" in the places list view always showed an empty column header.
This fixes this to show the correct header "Title".